### PR TITLE
Add target framework net 6 for fluent metadata

### DIFF
--- a/FluentMetadata.Tests/FluentMetadata.Tests.Web/FluentMetadata.Tests.Web.csproj
+++ b/FluentMetadata.Tests/FluentMetadata.Tests.Web/FluentMetadata.Tests.Web.csproj
@@ -76,10 +76,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OpenRiaServices.Hosting.Wcf">
-      <Version>5.0.0</Version>
+      <Version>5.1.2</Version>
     </PackageReference>
     <PackageReference Include="OpenRiaServices.Server">
-      <Version>5.0.0</Version>
+      <Version>5.1.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/FluentMetadata.Tests/FluentMetadata.Tests/FluentMetadata.Tests.csproj
+++ b/FluentMetadata.Tests/FluentMetadata.Tests/FluentMetadata.Tests.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="OpenRiaServices.Client.Core" Version="5.0.0" />
-    <PackageReference Include="OpenRiaServices.Client.CodeGen" Version="5.0.0">
+    <PackageReference Include="OpenRiaServices.Client.Core" Version="5.1.2" />
+    <PackageReference Include="OpenRiaServices.Client.CodeGen" Version="5.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/FluentMetadata/OpenRiaServices.Server.FluentMetadata.csproj
+++ b/FluentMetadata/OpenRiaServices.Server.FluentMetadata.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <Description>library that provides a fluent configuration interface for configuring domain services.</Description>
     <PackageId>OpenRiaServices.FluentMetadata</PackageId>
     <GeneratePackageOnBuild Condition="'$(BUILD_BUILDID)' != ''">true</GeneratePackageOnBuild>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenRiaServices.Server" Version="5.0.0" />
+    <PackageReference Include="OpenRiaServices.Server" Version="5.1.2" />
   </ItemGroup>
 
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,5 @@
 # .NET Desktop
 # Build and run tests for .NET Desktop or Windows classic desktop solutions.
-# Add steps that publish symbols, save build artifacts, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
 
 trigger:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,15 @@ steps:
   inputs:
     versionSpec: '5.x'
 
+- task: NuGetToolInstaller@1
+  inputs:
+    checkLatest: true
+
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '6.x'
+    
 - task: gitversion/execute@0
   displayName: Use GitVersion
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ steps:
 
 - task: NuGetToolInstaller@1
   inputs:
-    checkLatest: true
+    versionSpec: '6.3.1'
 
 - task: UseDotNet@2
   inputs:


### PR DESCRIPTION
Add target framework net 6 for fluent metadata and upgrade OpenRiaServices to 5.1.2